### PR TITLE
Update datasource URL to use DATABASE_URL

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DEV_DATABASE_URL"),
+    url: env("DATABASE_URL"),
   },
 });


### PR DESCRIPTION
Changed the datasource URL in prisma.config.ts from DEV_DATABASE_URL to DATABASE_URL to standardize environment variable usage.