### PR TITLE
Use DATABASE_URL for Prisma connection

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 
-const connectionString = `${process.env.DEV_DATABASE_URL}`;
+const connectionString = `${process.env.DATABASE_URL}`;
 
 const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });


### PR DESCRIPTION
Replaces DEV_DATABASE_URL with DATABASE_URL in the Prisma connection string to standardize environment variable usage.