### PR TITLE
Use environment variable for CORS origin

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,8 +12,8 @@ const app = express();
 const PORT = process.env.PORT || 8000;
 
 const corsOption = {
-  // origin: process.env.FRONTEND_URL!,
-  origin: "http://localhost:3000",
+  origin: process.env.FRONTEND_URL!,
+  // origin: "http://localhost:3000",
   methods: ["GET", "POST", "PUT", "DELETE"], // Specify allowed HTTP methods
   credentials: true, // Allow credentials (cookies, authorization headers, etc.)
   optionsSuccessStatus: 200, // Some legacy browsers choke on 204


### PR DESCRIPTION
Updated the CORS configuration to use the FRONTEND_URL environment variable for the allowed origin instead of the hardcoded localhost URL.