### PR TITLE
fix: Update SameSite attribute for refreshToken cookie to "none"

### DIFF
--- a/src/controllers/v1/auth.controller.ts
+++ b/src/controllers/v1/auth.controller.ts
@@ -23,7 +23,7 @@ export const createUser = async (req: Request, res: Response) => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     secure: true,
-    sameSite: false,
+    sameSite: "none",
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
   });
 
@@ -42,7 +42,7 @@ export const loginUser = async (req: Request, res: Response) => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     secure: true,
-    sameSite: false,
+    sameSite: "none",
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
   });
 
@@ -63,7 +63,7 @@ export const logoutUser = async (req: Request, res: Response) => {
   res.clearCookie("refreshToken", {
     httpOnly: true,
     secure: true,
-    sameSite: false,
+    sameSite: "none",
   });
 
   sendSuccessResponse(res, 200, "User logged out successfully");
@@ -108,7 +108,7 @@ export const refreshToken = async (req: Request, res: Response) => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     secure: true,
-    sameSite: false,
+    sameSite: "none",
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
   });
 


### PR DESCRIPTION
This pull request updates the cookie configuration for authentication endpoints to improve compatibility with cross-site requests. The `sameSite` attribute for the `refreshToken` cookie is changed from `false` to `"none"` in all relevant controller methods.

Cookie configuration updates:

* Changed the `sameSite` attribute from `false` to `"none"` when setting the `refreshToken` cookie in the `createUser`, `loginUser`, and `refreshToken` controller methods in `src/controllers/v1/auth.controller.ts` [[1]](diffhunk://#diff-1ceb4343c05cce5abecde3b3960365db5b069df2bc4f4013188babf528a70898L26-R26) [[2]](diffhunk://#diff-1ceb4343c05cce5abecde3b3960365db5b069df2bc4f4013188babf528a70898L45-R45) [[3]](diffhunk://#diff-1ceb4343c05cce5abecde3b3960365db5b069df2bc4f4013188babf528a70898L111-R111).
* Updated the `sameSite` attribute to `"none"` when clearing the `refreshToken` cookie in the `logoutUser` controller method in `src/controllers/v1/auth.controller.ts`.