### PR TITLE
Refactor to use DATABASE_URL for connection string

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 
-const connectionString = `${process.env.DEV_DATABASE_URL}`;
+const connectionString = `${process.env.DATABASE_URL}`;
 const adapter = new PrismaPg({ connectionString });
 
 const prisma = new PrismaClient({ adapter });


### PR DESCRIPTION
This pull request makes a small configuration change to the database connection in `src/lib/db.ts`. The environment variable used for the database URL has been updated to use `DATABASE_URL` instead of `DEV_DATABASE_URL`