### PR TITLE
Enhance findProfileByUserId to include detailed academic information

### DIFF
--- a/src/infra/repos/profile.repo.ts
+++ b/src/infra/repos/profile.repo.ts
@@ -32,7 +32,9 @@ const profileIncludes = {
 } satisfies Prisma.ProfileInclude;
 
 // find profile by userId
-const findProfileByUserId = async (userId: string): Promise<Profile | null> => {
+type ProfileWithAcademicInfo = Prisma.ProfileGetPayload<{ include: typeof profileIncludes }>;
+
+const findProfileByUserId = async (userId: string): Promise<ProfileWithAcademicInfo | null> => {
   return await prisma.profile.findUnique({
     where: {
       userId: userId,


### PR DESCRIPTION
This pull request updates the `findProfileByUserId` function in `src/infra/repos/profile.repo.ts` to improve type safety and ensure it returns a profile object that includes related academic information.

Type and return value improvements:

* Introduced a new type alias `ProfileWithAcademicInfo` using `Prisma.ProfileGetPayload` to represent a profile with included academic info, and updated the return type of `findProfileByUserId` to use this new type.