### PR TITLE
chore: Delete refresh token by token; stop revoking on login

### DIFF
--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -77,8 +77,6 @@ const loginUser = async (
     role: user.role,
   });
 
-  await userRepos.revokeRefreshToken(user.id);
-
   await userRepos.storeRefreshToken({
     userId: user.id,
     refreshToken,
@@ -120,7 +118,7 @@ const refreshAccessToken = async (refreshToken: string, device?: DeviceInfo) => 
     role: user.role,
   });
 
-  await userRepos.revokeRefreshToken(user.id);
+  await userRepos.deleteRefreshToken(refreshToken);
 
   await userRepos.storeRefreshToken({
     userId: user.id,


### PR DESCRIPTION
Remove global revocation during login and replace user-wide revoke with token-specific delete during refresh. This avoids invalidating all of a user's refresh tokens on login and ensures only the presented refresh token is removed when rotating tokens, preserving other device sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication token management to revoke only the current token during refresh operations instead of invalidating all active sessions, enabling better support for concurrent user sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/acadxp/acadxp-backend/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->